### PR TITLE
Add MediaWiki Content Security Policy support

### DIFF
--- a/includes/EmbedService/AbstractEmbedService.php
+++ b/includes/EmbedService/AbstractEmbedService.php
@@ -162,6 +162,13 @@ abstract class AbstractEmbedService {
 	}
 
 	/**
+	 * Returns an array of Content Security Policy urls for this service.
+	 *
+	 * @return array
+	 */
+	abstract public function getCSPUrls(): array;
+
+	/**
 	 * Set the width of the player.  This also will set the height automatically.
 	 * Width will be automatically constrained to the minimum and maximum widths.
 	 *

--- a/includes/EmbedService/ArchiveOrg.php
+++ b/includes/EmbedService/ArchiveOrg.php
@@ -51,4 +51,13 @@ final class ArchiveOrg extends AbstractEmbedService {
 			'#^([\d\w\-_][^/\?\#]+)$#is'
 		];
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCSPUrls(): array {
+		return [
+			'https://archive.org'
+		];
+	}
 }

--- a/includes/EmbedService/SoundCloud.php
+++ b/includes/EmbedService/SoundCloud.php
@@ -55,4 +55,13 @@ final class SoundCloud extends AbstractEmbedService {
 	protected function getIdRegex(): array {
 		return [];
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCSPUrls(): array {
+		return [
+			'https://w.soundcloud.com'
+		];
+	}
 }

--- a/includes/EmbedService/Spotify/SpotifyAlbum.php
+++ b/includes/EmbedService/Spotify/SpotifyAlbum.php
@@ -56,4 +56,13 @@ class SpotifyAlbum extends AbstractEmbedService {
 			'#^([a-zA-Z0-9]+)$#is'
 		];
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCSPUrls(): array {
+		return [
+			'https://open.spotify.com'
+		];
+	}
 }

--- a/includes/EmbedService/Twitch/Twitch.php
+++ b/includes/EmbedService/Twitch/Twitch.php
@@ -75,4 +75,13 @@ class Twitch extends AbstractEmbedService {
 
 		return sprintf( '%s&%s', sprintf( $this->getBaseUrl(), $this->getId() ), $urlArgs );
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCSPUrls(): array {
+		return [
+			'https://player.twitch.tv'
+		];
+	}
 }

--- a/includes/EmbedService/Vimeo.php
+++ b/includes/EmbedService/Vimeo.php
@@ -52,4 +52,15 @@ final class Vimeo extends AbstractEmbedService {
 			'#^([\d]+)$#is'
 		];
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCSPUrls(): array {
+		return [
+			'https://vimeo.com',
+			'https://i.vimeocdn.com',
+			'https://player.vimeo.com'
+		];
+	}
 }

--- a/includes/EmbedService/YouTube/YouTube.php
+++ b/includes/EmbedService/YouTube/YouTube.php
@@ -78,8 +78,8 @@ class YouTube extends AbstractEmbedService {
 	 */
 	public function getCSPUrls(): array {
 		return [
-			'//www.youtube-nocookie.com',
-			'//i.ytimg.com'
+			'https://www.youtube-nocookie.com',
+			'https://i.ytimg.com'
 		];
 	}
 }

--- a/includes/EmbedService/YouTube/YouTube.php
+++ b/includes/EmbedService/YouTube/YouTube.php
@@ -72,4 +72,14 @@ class YouTube extends AbstractEmbedService {
 
 		return parent::getUrl();
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getCSPUrls(): array {
+		return [
+			'//www.youtube-nocookie.com',
+			'//i.ytimg.com'
+		];
+	}
 }

--- a/includes/EmbedVideo.php
+++ b/includes/EmbedVideo.php
@@ -418,7 +418,7 @@ HTML;
 		// Add CSP if needed
 		$defaultSrcArr = $this->service->getCSPUrls();
 		if ( $defaultSrcArr ) {
-			foreach ( $defaultSrcArr as &$defaultSrc ) {
+			foreach ( $defaultSrcArr as $defaultSrc ) {
 				$out->addExtraCSPDefaultSrc( $defaultSrc );
 			}
 		}

--- a/includes/EmbedVideo.php
+++ b/includes/EmbedVideo.php
@@ -414,6 +414,15 @@ HTML;
 		}
 
 		$out = $this->parser->getOutput();
+
+		// Add CSP if needed
+		$defaultSrcArr = $this->service->getCSPUrls();
+		if ( $defaultSrcArr ) {
+			foreach ( $defaultSrcArr as &$defaultSrc ) {
+				$out->addExtraCSPDefaultSrc( $defaultSrc );
+			}
+		}
+
 		$out->addModules( 'ext.embedVideo' );
 		$out->addModuleStyles( 'ext.embedVideo.styles' );
 


### PR DESCRIPTION
The extension should add the required CSP policies on necessary pages, when the MediaWiki CSP feature is enabled.
This will allow a tighter CSP policy since wikis don't have to allow the embed domains site-wide on the wiki.