### PR TITLE
feat: Use Do Not Track for Vimeo service

### DIFF
--- a/includes/EmbedService/Vimeo.php
+++ b/includes/EmbedService/Vimeo.php
@@ -10,7 +10,7 @@ final class Vimeo extends AbstractEmbedService {
 	 * @inheritDoc
 	 */
 	public function getBaseUrl(): string {
-		return '//player.vimeo.com/video/%1$s';
+		return '//player.vimeo.com/video/%1$s?dnt=true';
 	}
 
 	/**


### PR DESCRIPTION
From Vimeo:

> Setting this parameter to "true" will block the player from tracking any session data, including all cookies and [analytics](https://vimeo.com/stats).

https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview