### PR TITLE
fixed getUrl() for Bilibili

### DIFF
--- a/includes/EmbedService/Bilibili.php
+++ b/includes/EmbedService/Bilibili.php
@@ -76,16 +76,13 @@ final class Bilibili extends AbstractEmbedService {
 	}
 
 	/**
-	 * Add '&page=1' if not set through parser
-	 *
-	 * @return string
+	 * @inheritDoc
 	 */
 	public function getUrl(): string {
-		$page = 'page=1';
 		if ( $this->getUrlArgs() !== false ) {
-			$page = $this->getUrlArgs();
+			return sprintf( '%s&%s', sprintf( $this->getBaseUrl(), $this->getId() ), $this->getUrlArgs() );
 		}
 
-		return sprintf( '%s&%s', parent::getUrl(), $page );
+		return sprintf( $this->getBaseUrl(), $this->getId() );
 	}
 }


### PR DESCRIPTION
1. The previous implementation was totally wrong. For example, for `| id=abcd | urlArgs=autoplay=1`, the expected result was: `//player.bilibili.com/player.html?bvid=abcd&page=1&autoplay=1` And the actual result was:
`//player.bilibili.com/player.html?bvid=abcd?autoplay=1&autoplay=1`
2. `page=1` is not required. Bilibili does not actually rely on the **page** argument to determine video paging, but uses the **cid** argument (not required). So we don't have to add `page=1` to the Url.

