### PR TITLE
fixed XSS: unsafe negative character class in ArchiveOrg.php

### DIFF
--- a/includes/EmbedService/ArchiveOrg.php
+++ b/includes/EmbedService/ArchiveOrg.php
@@ -39,7 +39,7 @@ final class ArchiveOrg extends AbstractEmbedService {
 	 */
 	protected function getUrlRegex(): array {
 		return [
-			'#archive\.org/(?:details|embed)/([\d\w\-_][^/\?\#]+)#is'
+			'#archive\.org/(?:details|embed)/([\d\w\-_][^/\?\#\'"<>]+)#is'
 		];
 	}
 

--- a/includes/EmbedService/SoundCloud.php
+++ b/includes/EmbedService/SoundCloud.php
@@ -46,7 +46,7 @@ final class SoundCloud extends AbstractEmbedService {
 	 */
 	protected function getUrlRegex(): array {
 		return [
-			'#^(https://soundcloud\.com/.+?/.+?)$#is',
+			'#^(https://soundcloud\.com/[\w\-\.]+[/]+[\w\-\.]+/?)$#is',
 		];
 	}
 


### PR DESCRIPTION
Hi! I've looked at all classes for embedding services and found the same problem as #53 in `ArchiveOrg.php`.
Other classes seem now to be XSS-safe.