### PR TITLE
Fixed issue #115 as well as another issue that would break the Description2 extension

### DIFF
--- a/includes/EmbedService/EmbedHtmlFormatter.php
+++ b/includes/EmbedService/EmbedHtmlFormatter.php
@@ -111,8 +111,8 @@ final class EmbedHtmlFormatter {
 		 * @see https://www.mediawiki.org/wiki/Specs/HTML/2.7.0#Audio/Video
 		 */
 		$template = <<<HTML
-			<figure class="%s" data-service="%s" %s %s><!--
-				--><div class="embedvideo-wrapper" %s>%s%s</div>%s
+			<figure class="%s" data-service="%s" %s %s>
+				<div class="embedvideo-wrapper" %s>%s%s</div>%s
 			</figure>
 			HTML;
 
@@ -194,8 +194,8 @@ final class EmbedHtmlFormatter {
 
 			// phpcs:disable
 			return <<<HTML
-				<picture class="embedvideo-thumbnail"><!--
-				--><img src="{$url}" loading="lazy" class="embedvideo-thumbnail__image" alt="Thumbnail for {$service->getTitle()}"/>
+				<picture class="embedvideo-thumbnail">
+					<img src="{$url}" loading="lazy" class="embedvideo-thumbnail__image" alt="Thumbnail for {$service->getTitle()}"/>
 				</picture>
 				HTML;
 			// phpcs:enable
@@ -232,23 +232,23 @@ final class EmbedHtmlFormatter {
 	 */
 	public static function makeConsentContainerHtml( AbstractEmbedService $service ): string {
 		$template = <<<HTML
-<div class="embedvideo-consent" data-show-privacy-notice="%s">%s<!--
---><div class="embedvideo-overlay"><!--
-	--><div class="embedvideo-loader" role="button">%s<!--
-		--><div class="embedvideo-loader__fakeButton">%s</div><!--
-		--><div class="embedvideo-loader__footer"><!--
-			--><div class="embedvideo-loader__service">%s</div><!--
-		--></div><!--
-	--></div><!--
-	--><div class="embedvideo-privacyNotice hidden"><!--
-		--><div class="embedvideo-privacyNotice__content">%s%s</div><!--
-		--><div class="embedvideo-privacyNotice__buttons"><!--
-			--><button class="embedvideo-privacyNotice__continue">%s</button><!--
-			--><button class="embedvideo-privacyNotice__dismiss">%s</button><!--
-		--></div><!--
-	--></div><!--
---></div><!--
---></div>
+<div class="embedvideo-consent" data-show-privacy-notice="%s">%s
+	<div class="embedvideo-overlay">
+		<div class="embedvideo-loader" role="button">%s
+			<div class="embedvideo-loader__fakeButton">%s</div>
+			<div class="embedvideo-loader__footer">
+				<div class="embedvideo-loader__service">%s</div>
+			</div>
+		</div>
+		<div class="embedvideo-privacyNotice hidden">
+			<div class="embedvideo-privacyNotice__content">%s%s</div>
+			<div class="embedvideo-privacyNotice__buttons">
+				<button class="embedvideo-privacyNotice__continue">%s</button>
+				<button class="embedvideo-privacyNotice__dismiss">%s</button>
+			</div>
+		</div>
+	</div>
+</div>
 HTML;
 
 		$showPrivacyNotice = false;

--- a/includes/EmbedService/YouTube/YouTube.php
+++ b/includes/EmbedService/YouTube/YouTube.php
@@ -45,7 +45,7 @@ class YouTube extends AbstractEmbedService {
 	 * @inheritDoc
 	 */
 	public function getBaseUrl(): string {
-		return '//www.youtube-nocookie.com/embed/%1$s';
+		return 'https://www.youtube-nocookie.com/embed/%1$s';
 	}
 
 	/**


### PR DESCRIPTION
Hello @octfx, here is a PR that fixes the compatibility issue with mediawiki/iframe-tag as well as another issue I found, that would break the Description2 extension (the html comments that were surrounding the carriage returns). Removing the comments fixes the issue...