### PR TITLE
Use namespaced GlobalVarConfig

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -184,7 +184,7 @@
 		}
 	},
 	"ConfigRegistry": {
-		"EmbedVideo": "GlobalVarConfig::newInstance"
+		"EmbedVideo": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
 	"ExtensionFunctions": [
 		"MediaWiki\\Extension\\EmbedVideo\\EmbedVideoHooks::setup"
@@ -206,3 +206,4 @@
 	},
 	"manifest_version": 2
 }
+


### PR DESCRIPTION
The non-namespaced class alias was deprecated in MW 1.41. See also https://phabricator.wikimedia.org/T402038