### PR TITLE
Update Alugha privacy policy URL

### DIFF
--- a/includes/EmbedService/Alugha.php
+++ b/includes/EmbedService/Alugha.php
@@ -35,7 +35,7 @@ final class Alugha extends AbstractEmbedService {
 	 * @inheritDoc
 	 */
 	public function getPrivacyPolicyUrl(): ?string {
-		return 'https://alugha.com/legal/privacy-policy';
+    return 'https://alugha.com/cms/privacy/';
 	}
 
 	/**

--- a/includes/EmbedService/Alugha.php
+++ b/includes/EmbedService/Alugha.php
@@ -35,7 +35,7 @@ final class Alugha extends AbstractEmbedService {
 	 * @inheritDoc
 	 */
 	public function getPrivacyPolicyUrl(): ?string {
-    return 'https://alugha.com/cms/privacy/';
+	  return 'https://alugha.com/cms/privacy/';
 	}
 
 	/**


### PR DESCRIPTION
Closes #191 

## Summary

Updates the Alugha privacy policy URL from the outdated `/legal/privacy-policy` path to the correct `/cms/privacy/` URL.

## Changed

```php
return 'https://alugha.com/cms/privacy/';
```

## Notes

No functional behavior changes besides correcting the privacy policy link exposed by the Alugha embed service.
