### PR TITLE
fix: local audio/video fail to render on MW 1.46 ("Unable to save thumbnail to destination")

### DIFF
--- a/includes/Media/AudioHandler.php
+++ b/includes/Media/AudioHandler.php
@@ -116,8 +116,7 @@ class AudioHandler extends MediaHandler {
 	 * @return string
 	 */
 	public function makeParamString( $params ): string {
-		// Width does not matter to video or audio.
-		return '';
+		return (string)( $params['width'] ?? 0 ) . 'px-';
 	}
 
 	/**


### PR DESCRIPTION
## Problem

On MediaWiki 1.46, any local audio or video file rendered with standard file syntax (e.g. `[[File:Example.mp4|500px]]`) fails with:
> Error creating thumbnail: Unable to save thumbnail to destination

## Cause

`AudioHandler::makeParamString()` returns an empty string, since no actual thumbnail image is produced (`doTransform()` ignores `$dstPath` /  `$dstUrl` and returns an HTML5 `<video>` / `<audio>` element instead).

However, core computes and validates a thumbnail path *before* calling `doTransform()`, and an empty param string breaks that path.

## Fix
Return a non-empty param string. The exact value is irrelevant since no image is ever written (it only needs to produce a well-formed path and a clean file extension). `parseParamString()` is updated to match for symmetry.