### PR TITLE
Workflow CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,15 @@ jobs:
           - mw: 'REL1_43'
             php: 8.1
             experimental: false
-          - mw: 'REL1_44'
-            php: 8.2
-            experimental: false
           - mw: 'REL1_45'
             php: 8.3
             experimental: false
+          - mw: 'REL1_46'
+            php: 8.3
+            experimental: false
+          - mw: 'master'
+            php: 8.4
+            experimental: true
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/fetchPhpunitConf.sh
+++ b/.github/workflows/fetchPhpunitConf.sh
@@ -20,8 +20,12 @@ if [ ! -f phpunit.xml.dist ]; then
 fi
 
 if [ ! -s phpunit.xml.dist ]; then
-  echo "Error: phpunit.xml.dist is empty!"
-  exit 1
+  echo "Error: phpunit.xml.dist is empty! Attempting to download phpunit.xml.template instead!"
+  wget https://raw.githubusercontent.com/wikimedia/mediawiki/${MW_BRANCH}/phpunit.xml.template -O phpunit.xml.template
+  if [ ! -s phpunit.xml.template ]; then
+    echo "Error: phpunit.xml.template is empty!"
+    exit 1
+  fi
 fi
 
 echo "phpunit.xml.dist downloaded successfully."

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,13 @@
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true
+		},
+		"policy": {
+			"advisories": {
+				"ignore-id": {
+					"PKSA-rdkp-vv9z-mjkg": "This package is only run in workflow environments."
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Updating ci.yml, removing REL1_44 as it was deprecated in July, adding REL1_46 as it is the latest stable release, and adding master as experimental as REL1_47 is not published yet, adding config.policy.advisories.ignore-id setting for squizlabs/php_codesniffer so the lint job can run without upgrading it to use PHP 8.3, and adding an extra if check in fetchPhpunitConf.sh as in REL1_46 they renamed phpunit.xml.dist to phpunit.xml.template.