### PR TITLE
fix: MediaWiki 1.46 deprecations and 1.43 compatibility fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Updating Privacy Policy URLs for applicable services
 * Updating CHANGED.md and README.md for better maintainability
 * Fixed the deprecated `$restriction` special page constructor parameter on MediaWiki 1.46
+* Special:RefreshEmbedVideoMetadata now enforces the `embedvideo-refreshmetadata` right it declares
 
 ### v4.1.0
 * Added the Alugha video and audio hosting service.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Fixed the deprecated `$restriction` special page constructor parameter on MediaWiki 1.46
 * Special:RefreshEmbedVideoMetadata now enforces the `embedvideo-refreshmetadata` right it declares
 * Fixed a fatal error in the BackfillLocalMediaMetadata maintenance script on MediaWiki 1.43
+* Fixed a MediaWiki 1.46 deprecation notice on audio and video file description pages
 
 ### v4.1.0
 * Added the Alugha video and audio hosting service.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Fixing a spelling mistake in a CSP URL for nicovideo.jp
 * Updating Privacy Policy URLs for applicable services
 * Updating CHANGED.md and README.md for better maintainability
+* Fixed the deprecated `$restriction` special page constructor parameter on MediaWiki 1.46
 
 ### v4.1.0
 * Added the Alugha video and audio hosting service.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 * Updating CHANGED.md and README.md for better maintainability
 * Fixed the deprecated `$restriction` special page constructor parameter on MediaWiki 1.46
 * Special:RefreshEmbedVideoMetadata now enforces the `embedvideo-refreshmetadata` right it declares
+* Fixed a fatal error in the BackfillLocalMediaMetadata maintenance script on MediaWiki 1.43
 
 ### v4.1.0
 * Added the Alugha video and audio hosting service.

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -47,6 +47,7 @@
 	"embedvideo-service-youtube": "{{Optional}}\nThe name of YouTube, a live streaming and video hosting service, see https://www.youtube.com/.",
 	"embedvideo-service-localvideo": "Label for local video file service.",
 	"embedvideo-service-externalvideo": "Label for external video service.",
+	"embedvideo-play": "Label for the play button shown on the embed placeholder before the player is loaded.",
 	"embedvideo-refreshmetadata-tab": "Label for the file-page action tab that opens the special page for refreshing stored EmbedVideo metadata.",
 	"embedvideo-refreshmetadata-submit": "Label for the submit button on Special:RefreshEmbedVideoMetadata.",
 	"embedvideo-refreshmetadata-intro": "Introductory text on Special:RefreshEmbedVideoMetadata. $1 is the prefixed file title.",

--- a/includes/Media/AudioHandler.php
+++ b/includes/Media/AudioHandler.php
@@ -6,6 +6,7 @@ namespace MediaWiki\Extension\EmbedVideo\Media;
 
 use MediaHandler;
 use MediaTransformOutput;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Extension\EmbedVideo\Media\FFProbe\FFProbe;
 use MediaWiki\Extension\EmbedVideo\Media\TransformOutput\AudioTransformOutput;
 use MediaWiki\FileRepo\File\File;
@@ -216,7 +217,9 @@ class AudioHandler extends MediaHandler {
 		$metadata = $file->getMetadataItems( [ 'duration' ] );
 		$duration = $metadata['duration'] ?? null;
 		if ( $duration === null || $duration === false || $duration === '' ) {
-			return self::getGeneralShortDesc( $file );
+		// The general fallbacks are user-language, matching what core used before it
+		// took an explicit $lang; the branches above deliberately stay content-language.
+			return self::getGeneralShortDesc( $file, RequestContext::getMain()->getLanguage() );
 		}
 
 		return wfMessage(
@@ -253,7 +256,9 @@ class AudioHandler extends MediaHandler {
 		}
 
 		if ( count( $parts ) === 1 ) {
-			return self::getGeneralLongDesc( $file );
+		// The general fallbacks are user-language, matching what core used before it
+		// took an explicit $lang; the branches above deliberately stay content-language.
+			return self::getGeneralLongDesc( $file, RequestContext::getMain()->getLanguage() );
 		}
 
 		return $this->contentLanguage->commaList( $parts );

--- a/includes/Media/VideoHandler.php
+++ b/includes/Media/VideoHandler.php
@@ -228,7 +228,9 @@ class VideoHandler extends AudioHandler {
 		}
 
 		if ( !$parts ) {
-			return self::getGeneralShortDesc( $file );
+		// The general fallbacks are user-language, matching what core used before it
+		// took an explicit $lang; the branches above deliberately stay content-language.
+			return self::getGeneralShortDesc( $file, RequestContext::getMain()->getLanguage() );
 		}
 
 		return $this->contentLanguage->commaList( $parts );
@@ -267,7 +269,9 @@ class VideoHandler extends AudioHandler {
 		}
 
 		if ( count( $parts ) === 1 ) {
-			return self::getGeneralLongDesc( $file );
+		// The general fallbacks are user-language, matching what core used before it
+		// took an explicit $lang; the branches above deliberately stay content-language.
+			return self::getGeneralLongDesc( $file, RequestContext::getMain()->getLanguage() );
 		}
 
 		return $this->contentLanguage->commaList( $parts );

--- a/includes/Specials/SpecialRefreshEmbedVideoMetadata.php
+++ b/includes/Specials/SpecialRefreshEmbedVideoMetadata.php
@@ -61,8 +61,9 @@ class SpecialRefreshEmbedVideoMetadata extends UnlistedSpecialPage {
 	 * @return void
 	 */
 	public function execute( $par ): void {
-		$this->checkReadOnly();
 		$this->setHeaders();
+		$this->checkPermissions();
+		$this->checkReadOnly();
 		$this->outputHeader();
 
 		$out = $this->getOutput();

--- a/includes/Specials/SpecialRefreshEmbedVideoMetadata.php
+++ b/includes/Specials/SpecialRefreshEmbedVideoMetadata.php
@@ -17,6 +17,11 @@ use RepoGroup;
 
 class SpecialRefreshEmbedVideoMetadata extends UnlistedSpecialPage {
 	/**
+	 * Right a user must hold to refresh stored metadata.
+	 */
+	private const RESTRICTION = 'embedvideo-refreshmetadata';
+
+	/**
 	 * @param RepoGroup $repoGroup
 	 * @param TitleFactory $titleFactory
 	 */
@@ -24,7 +29,24 @@ class SpecialRefreshEmbedVideoMetadata extends UnlistedSpecialPage {
 		private RepoGroup $repoGroup,
 		private TitleFactory $titleFactory
 	) {
-		parent::__construct( 'RefreshEmbedVideoMetadata', 'embedvideo-refreshmetadata' );
+		// MediaWiki 1.46 deprecated the $restriction constructor parameter in favour of
+		// overriding getRestriction(). The parameter still has to be passed on older
+		// releases: before 1.46, userCanExecute(), isRestricted() and
+		// displayRestrictionError() read the property the constructor sets and never
+		// consult getRestriction(), so dropping it there would make those methods report
+		// that no right is required.
+		if ( version_compare( MW_VERSION, '1.46', '<' ) ) {
+			parent::__construct( 'RefreshEmbedVideoMetadata', self::RESTRICTION );
+		} else {
+			parent::__construct( 'RefreshEmbedVideoMetadata' );
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getRestriction(): string {
+		return self::RESTRICTION;
 	}
 
 	/**

--- a/maintenance/BackfillLocalMediaMetadata.php
+++ b/maintenance/BackfillLocalMediaMetadata.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\EmbedVideo\Maintenance;
 
+use MediaWiki\Deferred\DeferredUpdates;
 use MediaWiki\Extension\EmbedVideo\Media\AudioHandler;
 use MediaWiki\FileRepo\File\FileSelectQueryBuilder;
 use MediaWiki\Maintenance\Maintenance;
@@ -92,7 +93,7 @@ class BackfillLocalMediaMetadata extends Maintenance {
 			$res->rewind();
 
 			$lastName = null;
-			$this->beginTransactionRound( __METHOD__ );
+			$this->beginBatchTransaction( __METHOD__ );
 			foreach ( $res as $row ) {
 				$lastName = $row->img_name;
 
@@ -125,7 +126,7 @@ class BackfillLocalMediaMetadata extends Maintenance {
 					$failures[] = "File:$lastName failed: {$e->getMessage()}";
 				}
 			}
-			$this->commitTransactionRound( __METHOD__ );
+			$this->commitBatchTransaction( __METHOD__ );
 
 			if ( $lastName !== null ) {
 				$batchCondition = [ $dbw->expr( 'img_name', '>', $lastName ) ];
@@ -148,6 +149,48 @@ class BackfillLocalMediaMetadata extends Maintenance {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Begin a transaction round.
+	 *
+	 * Maintenance::beginTransactionRound() only exists since MediaWiki 1.44; call the
+	 * load balancer factory directly on older supported releases.
+	 *
+	 * @param string $fname
+	 * @return void
+	 */
+	private function beginBatchTransaction( string $fname ): void {
+		if ( version_compare( MW_VERSION, '1.44', '<' ) ) {
+			$this->getServiceContainer()->getDBLoadBalancerFactory()->beginPrimaryChanges( $fname );
+			return;
+		}
+
+		$this->beginTransactionRound( $fname );
+	}
+
+	/**
+	 * Commit a transaction round, wait for replication and drain deferred updates.
+	 *
+	 * Maintenance::commitTransactionRound() only exists since MediaWiki 1.44; on older
+	 * supported releases call the load balancer factory directly. waitForReplication()
+	 * covers the wait and autoReconfigure(), but not the opportunistic deferred update
+	 * run, which has to be triggered separately: the cache invalidations queued by
+	 * LocalFile::upgradeRow() cannot run while a transaction round is open, so without
+	 * this the queue would grow for the whole run.
+	 *
+	 * @param string $fname
+	 * @return void
+	 */
+	private function commitBatchTransaction( string $fname ): void {
+		if ( version_compare( MW_VERSION, '1.44', '<' ) ) {
+			$this->getServiceContainer()->getDBLoadBalancerFactory()->commitPrimaryChanges( $fname );
+			$this->waitForReplication();
+			DeferredUpdates::tryOpportunisticExecute();
+			return;
+		}
+
+		$this->commitTransactionRound( $fname );
 	}
 
 	/**

--- a/tests/phpunit/EmbedService/AlughaTest.php
+++ b/tests/phpunit/EmbedService/AlughaTest.php
@@ -14,6 +14,7 @@ use MediaWikiIntegrationTestCase;
  */
 class AlughaTest extends MediaWikiIntegrationTestCase {
 	private const VALID_ID = 'b8fe2460-81e1-11eb-8b27-65de6c3aea52';
+	private const EMBED_URL_PREFIX = 'https://alugha.com/embed/web-player?v=';
 
 	/**
 	 * A bare UUID is accepted and produces the expected embed src.
@@ -24,16 +25,23 @@ class AlughaTest extends MediaWikiIntegrationTestCase {
 		$service = EmbedServiceFactory::newFromName( 'alugha', self::VALID_ID );
 		$html = EmbedHtmlFormatter::toHtml( $service );
 
-		$this->assertStringContainsString( 'data-mw-iframeconfig="{&quot;src&quot;:&quot;https://alugha.com/embed/web-player?v=' . self::VALID_ID . '&quot;}"', $html );
-			// With consent enabled, no iframe is rendered until the user clicks.
-			$this->assertStringNotContainsString( '<iframe', $html );
+		$expectedConfig = 'data-mw-iframeconfig="{&quot;src&quot;:&quot;'
+			. self::EMBED_URL_PREFIX . self::VALID_ID
+			. '&quot;}"';
+		$this->assertStringContainsString( $expectedConfig, $html );
+
+		// With consent enabled, no iframe is rendered until the user clicks.
+		$this->assertStringNotContainsString( '<iframe', $html );
 	}
 
 	/**
 	 * A full Alugha embed URL is normalised to the same video id.
 	 */
 	public function testFullUrlIsParsed(): void {
-		$service = EmbedServiceFactory::newFromName( 'alugha', 'https://alugha.com/embed/web-player?v=' . self::VALID_ID );
-		$this->assertStringContainsString( 'https://alugha.com/embed/web-player?v=' . self::VALID_ID, EmbedHtmlFormatter::toHtml( $service ) );
+		$url = self::EMBED_URL_PREFIX . self::VALID_ID;
+
+		$service = EmbedServiceFactory::newFromName( 'alugha', $url );
+
+		$this->assertStringContainsString( $url, EmbedHtmlFormatter::toHtml( $service ) );
 	}
 }

--- a/tests/phpunit/SpecialRefreshEmbedVideoMetadataTest.php
+++ b/tests/phpunit/SpecialRefreshEmbedVideoMetadataTest.php
@@ -10,6 +10,7 @@ use MediaWiki\Extension\EmbedVideo\Media\AudioHandler;
 use MediaWiki\Extension\EmbedVideo\Specials\SpecialRefreshEmbedVideoMetadata;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\SpecialPage\SpecialPage;
+use PermissionsError;
 use RepoGroup;
 
 /**
@@ -36,9 +37,41 @@ class SpecialRefreshEmbedVideoMetadataTest extends \SpecialPageTestBase {
 		);
 	}
 
+	public function testGetRestrictionReturnsRequiredRight(): void {
+		$this->assertSame( 'embedvideo-refreshmetadata', $this->newSpecialPage()->getRestriction() );
+	}
+
+	public function testUserWithoutRightIsDenied(): void {
+		$performer = $this->getMutableTestUser()->getUser();
+		$this->overrideUserPermissions( $performer, [] );
+
+		$this->expectException( PermissionsError::class );
+		$this->executeSpecialPage( '', null, 'qqx', $performer );
+	}
+
+	public function testUserWithoutRightCannotRefreshMetadata(): void {
+		$performer = $this->getMutableTestUser()->getUser();
+		$this->overrideUserPermissions( $performer, [] );
+
+		// The permission check throws before the file is ever looked up, so these
+		// expectations are not reached today. They are here to fail if the check is
+		// ever moved below the form handling.
+		$file = $this->createMock( LocalFile::class );
+		$file->method( 'exists' )->willReturn( true );
+		$file->method( 'isLocal' )->willReturn( true );
+		$file->method( 'getRedirected' )->willReturn( null );
+		$file->method( 'getHandler' )->willReturn( new AudioHandler() );
+		$file->expects( $this->never() )->method( 'upgradeRow' );
+
+		$this->localRepo->method( 'newFile' )->willReturn( $file );
+
+		$this->expectException( PermissionsError::class );
+		$this->executeSpecialPage( 'Test.ogg', new FauxRequest( [], true ), 'qqx', $performer );
+	}
+
 	public function testMissingTargetShowsError(): void {
 		$performer = $this->getMutableTestUser()->getUser();
-		$this->overrideUserPermissions( $performer, [ 'embedvideo-refreshmetadata' => true ] );
+		$this->overrideUserPermissions( $performer, [ 'embedvideo-refreshmetadata' ] );
 
 		[ $html ] = $this->executeSpecialPage( '', null, 'qqx', $performer );
 
@@ -47,7 +80,7 @@ class SpecialRefreshEmbedVideoMetadataTest extends \SpecialPageTestBase {
 
 	public function testPostedRefreshCallsUpgradeRow(): void {
 		$performer = $this->getMutableTestUser()->getUser();
-		$this->overrideUserPermissions( $performer, [ 'embedvideo-refreshmetadata' => true ] );
+		$this->overrideUserPermissions( $performer, [ 'embedvideo-refreshmetadata' ] );
 
 		$file = $this->createMock( LocalFile::class );
 		$file->method( 'exists' )->willReturn( true );


### PR DESCRIPTION
Fixes #189.

Six commits, one per change. EmbedVideo supports MediaWiki 1.43 through 1.46, so each fix is checked against both ends of that range.

### 1. `fix(specials): stop using deprecated SpecialPage constructor parameters`

The reported deprecation. MediaWiki 1.46 deprecated the `$restriction` constructor parameter in favour of overriding `getRestriction()`.

The parameter can't simply be dropped, because we still support 1.43. Before 1.46, `userCanExecute()`, `isRestricted()` and `displayRestrictionError()` read the `$mRestriction` property the constructor sets and never call `getRestriction()` — only 1.46 switched them to the getter. Dropping the argument on 1.43–1.45 would leave those three public methods reporting that no right is required, since `PermissionManager::userHasRight()` returns `true` for an empty right.

So the constructor call is version-gated and `getRestriction()` is overridden, which 1.46+ picks up. Verified that passing exactly one argument silences both `wfDeprecated()` calls on 1.46 and master, and that `version_compare()` behaves correctly against `-alpha` versions.

### 2. `fix(specials): enforce the embedvideo-refreshmetadata right`

While confirming the above, the right turned out not to be enforced at all.

`SpecialRefreshEmbedVideoMetadata` overrides `SpecialPage::execute()`, which is the only place core calls `checkPermissions()` — neither `SpecialPage::run()` nor `SpecialPageFactory::executePath()` checks anything. The `embedvideo-refreshmetadata` right declared in `extension.json` was therefore never consulted on any supported version; the `isAllowed()` check on the file page tab only hid the link.

This adds the `checkPermissions()` call, ordered as core's default `execute()` does.

The existing tests couldn't have caught it: they passed `[ 'embedvideo-refreshmetadata' => true ]` to `overrideUserPermissions()`, which takes a *list* of right names, so nothing was actually granted. Corrected, plus coverage for `getRestriction()` and for a user without the right.

### 3. `fix(maintenance): restore MediaWiki 1.43 support in BackfillLocalMediaMetadata`

`Maintenance::beginTransactionRound()` / `commitTransactionRound()` are `@since 1.44`. On 1.43 — our declared minimum — the script died with "Call to undefined method" on its first batch. Both calls now fall back to the load balancer factory methods those helpers delegate to.

CI can't catch this: the PHPUnit matrix has no REL1_44 entry and never runs the maintenance script.

### 4. `fix(media): pass a language to MediaHandler::getGeneral*Desc()`

The other 1.46 deprecation in the extension. `getGeneralShortDesc()` / `getGeneralLongDesc()` gained an optional `?Language` parameter and warn without it. The audio and video handlers hit these in their no-metadata fallback branches, so the notice appeared on file description pages and search results for any file whose stored metadata lacks a duration.

Passing `RequestContext::getMain()->getLanguage()` — the language 1.46 falls back to, and what `$wgLang` resolved to on 1.43 — so rendered output is unchanged. PHP ignores the extra argument on releases whose signature still takes only `$file`.

### 5–6. Drive-by CI fixes

Both lint jobs were already failing on `master` before this branch, which made it impossible to tell whether these changes were clean. Fixed so CI is green:

- `ci: fix PHPCS line length warnings in AlughaTest` — three `Generic.Files.LineLength.TooLong` warnings. This repo doesn't set `ignore_warnings_on_exit`, so phpcs exits non-zero on warnings and `composer test` had been failing since the Alugha service landed. Extracted the repeated embed URL into a constant and split the long assertions; no behaviour change. Also fixed two lines indented one level too deep.
- `ci: document embedvideo-play in qqq.json` — `embedvideo-play` was added to `en.json` without a `qqq.json` entry, failing `npm run lint:i18n`. Added at the position matching `en.json`, since the two files share a key order banana-checker doesn't enforce.

## Testing

CI is green on all six checks, including **MW 1.46 and master**, which is the configuration issue #189 was reported against.

Locally, against MediaWiki 1.43.9 / PHP 8.3:

- `composer phpunit -- --group EmbedVideo` — 456 tests. The only local failure is `SpecialRefreshEmbedVideoMetadataTest::testPostedRefreshCallsUpgradeRow`, which fails identically on `origin/master`: a dev wiki with InstantCommons enabled makes `addBacklinkSubtitle()` trigger a blocked `ForeignAPIRepo` request to Commons. CI's plain SQLite install has no foreign repo, so it passes there.
- `composer test` (parallel-lint, phpcs, minus-x) — clean.
- `npm run lint:js`, `lint:styles`, `lint:i18n` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANPKNXvfEoDAv3um6EHhTd
